### PR TITLE
chore: upgrade toolchain, dependencies, and migrate from kapt to ksp

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,11 +1,16 @@
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.jetbrains.kotlin.android)
     alias(libs.plugins.hilt.android)
-    alias(libs.plugins.kotlin.kapt)
+    alias(libs.plugins.ksp)
     alias(libs.plugins.kotlin.seriazation)
     alias(libs.plugins.kotlin.compose.compiler)
     alias(libs.plugins.kotlinx.kover)
+}
+
+kotlin {
+    compilerOptions {
+        languageVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_0
+    }
 }
 
 android {
@@ -50,12 +55,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-
-    kotlinOptions {
-        jvmTarget = "1.8"
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
 
     buildFeatures {
@@ -74,37 +75,39 @@ android {
     }
 }
 
-koverReport {
-    filters {
-        excludes {
-            classes(
-                "*.*BuildConfig*",
-                "*.*Module*",
-                "*.*Factory*",
-                "*.*CallAdapter*",
-                "*.*Hilt*",
-                "*.*Dao_Impl*",
-                "*.*Database*",
-                "*.*ComposableSingletons*",
-                "*.*Destination*",
-                "*.*Provider*",
-            )
-            packages(
-                "hilt_aggregated_deps",
-                "dagger.hilt.internal.aggregatedroot.codegen",
-                "com.tyme.github.users.*.di.*",
-                "com.tyme.github.users.extenstions",
-                "com.tyme.github.users.ui.uistate",
-                "com.tyme.github.users.core.ui.theme",
-                "com.tyme.github.users.core.ui.utils",
-                "com.tyme.github.users.core.ui.extensions",
-            )
-            annotatedBy(
-                "dagger.hilt.android.HiltAndroidApp",
-                "dagger.hilt.android.AndroidEntryPoint",
-                "androidx.compose.runtime.Composable",
-                "androidx.compose.ui.tooling.preview.Preview",
-            )
+kover {
+    reports {
+        filters {
+            excludes {
+                classes(
+                    "*.*BuildConfig*",
+                    "*.*Module*",
+                    "*.*Factory*",
+                    "*.*CallAdapter*",
+                    "*.*Hilt*",
+                    "*.*Dao_Impl*",
+                    "*.*Database*",
+                    "*.*ComposableSingletons*",
+                    "*.*Destination*",
+                    "*.*Provider*",
+                )
+                packages(
+                    "hilt_aggregated_deps",
+                    "dagger.hilt.internal.aggregatedroot.codegen",
+                    "com.tyme.github.users.*.di.*",
+                    "com.tyme.github.users.extenstions",
+                    "com.tyme.github.users.ui.uistate",
+                    "com.tyme.github.users.core.ui.theme",
+                    "com.tyme.github.users.core.ui.utils",
+                    "com.tyme.github.users.core.ui.extensions",
+                )
+                annotatedBy(
+                    "dagger.hilt.android.HiltAndroidApp",
+                    "dagger.hilt.android.AndroidEntryPoint",
+                    "androidx.compose.runtime.Composable",
+                    "androidx.compose.ui.tooling.preview.Preview",
+                )
+            }
         }
     }
 }
@@ -139,6 +142,7 @@ dependencies {
     implementation(libs.androidx.ui)
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
+    implementation(libs.compose.material.icons)
     implementation(libs.androidx.material3)
     implementation(libs.androidx.material3.adaptive)
     implementation(libs.androidx.material3.window.size.clazz)
@@ -149,7 +153,7 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
 
     implementation(libs.hilt.android)
-    kapt(libs.hilt.compiler)
+    ksp(libs.hilt.compiler)
     implementation(libs.hilt.navigation.compose)
 
     implementation(libs.androidx.paging.compose)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,9 +1,9 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     alias(libs.plugins.android.application) apply false
-    alias(libs.plugins.jetbrains.kotlin.android) apply false
     alias(libs.plugins.android.library) apply false
-    alias(libs.plugins.kotlin.kapt) apply false
+    alias(libs.plugins.ksp) apply false
     alias(libs.plugins.hilt.android) apply false
     alias(libs.plugins.kotlinx.kover) apply false
+    alias(libs.plugins.androidx.room) apply false
 }

--- a/core/common/build.gradle.kts
+++ b/core/common/build.gradle.kts
@@ -1,7 +1,12 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.jetbrains.kotlin.android)
     alias(libs.plugins.kotlinx.kover)
+}
+
+kotlin {
+    compilerOptions {
+        languageVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_0
+    }
 }
 
 android {
@@ -33,13 +38,10 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
 
-    kotlinOptions {
-        jvmTarget = "1.8"
-    }
 }
 
 dependencies {

--- a/core/config/build.gradle.kts
+++ b/core/config/build.gradle.kts
@@ -1,9 +1,14 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.jetbrains.kotlin.android)
     alias(libs.plugins.hilt.android)
-    alias(libs.plugins.kotlin.kapt)
+    alias(libs.plugins.ksp)
     alias(libs.plugins.kotlinx.kover)
+}
+
+kotlin {
+    compilerOptions {
+        languageVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_0
+    }
 }
 
 android {
@@ -31,10 +36,9 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
-    kotlinOptions { jvmTarget = "1.8" }
 
     buildFeatures { buildConfig = true }
 }
@@ -44,5 +48,5 @@ dependencies {
     implementation(project(":core:security"))
 
     implementation(libs.hilt.android)
-    kapt(libs.hilt.compiler)
+    ksp(libs.hilt.compiler)
 }

--- a/core/database/build.gradle.kts
+++ b/core/database/build.gradle.kts
@@ -1,9 +1,15 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.jetbrains.kotlin.android)
     alias(libs.plugins.hilt.android)
-    alias(libs.plugins.kotlin.kapt)
+    alias(libs.plugins.ksp)
     alias(libs.plugins.kotlinx.kover)
+    alias(libs.plugins.androidx.room)
+}
+
+kotlin {
+    compilerOptions {
+        languageVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_0
+    }
 }
 
 android {
@@ -15,11 +21,6 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles("consumer-rules.pro")
 
-        kapt {
-            arguments {
-                arg("room.schemaLocation", "$projectDir/schemas")
-            }
-        }
     }
 
     buildTypes {
@@ -46,16 +47,16 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-
-    kotlinOptions {
-        jvmTarget = "1.8"
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
 
     buildFeatures {
         buildConfig = true
+    }
+
+    room {
+        schemaDirectory("$projectDir/schemas")
     }
 }
 
@@ -63,11 +64,11 @@ dependencies {
     implementation(project(":core:security"))
 
     implementation(libs.hilt.android)
-    kapt(libs.hilt.compiler)
+    ksp(libs.hilt.compiler)
 
     implementation(libs.room.ktx)
     implementation(libs.room.paging)
-    kapt(libs.room.compiler)
+    ksp(libs.room.compiler)
 
     implementation(libs.sqlite.ktx)
     implementation(libs.sqlcipher.android)

--- a/core/navigation/build.gradle.kts
+++ b/core/navigation/build.gradle.kts
@@ -1,10 +1,15 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.jetbrains.kotlin.android)
     alias(libs.plugins.hilt.android)
-    alias(libs.plugins.kotlin.kapt)
+    alias(libs.plugins.ksp)
     alias(libs.plugins.kotlin.compose.compiler)
     alias(libs.plugins.kotlinx.kover)
+}
+
+kotlin {
+    compilerOptions {
+        languageVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_0
+    }
 }
 
 android {
@@ -20,10 +25,9 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
-    kotlinOptions { jvmTarget = "1.8" }
 
     buildFeatures {
         compose = true
@@ -39,5 +43,5 @@ dependencies {
     implementation(libs.kotlinx.coroutines.android)
 
     implementation(libs.hilt.android)
-    kapt(libs.hilt.compiler)
+    ksp(libs.hilt.compiler)
 }

--- a/core/network/build.gradle.kts
+++ b/core/network/build.gradle.kts
@@ -1,9 +1,14 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.jetbrains.kotlin.android)
     alias(libs.plugins.hilt.android)
-    alias(libs.plugins.kotlin.kapt)
+    alias(libs.plugins.ksp)
     alias(libs.plugins.kotlinx.kover)
+}
+
+kotlin {
+    compilerOptions {
+        languageVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_0
+    }
 }
 
 android {
@@ -19,17 +24,16 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
-    kotlinOptions { jvmTarget = "1.8" }
 }
 
 dependencies {
     implementation(project(":core:common"))
 
     implementation(libs.hilt.android)
-    kapt(libs.hilt.compiler)
+    ksp(libs.hilt.compiler)
 
     implementation(libs.retrofit)
     implementation(libs.retrofit.converter.gson)

--- a/core/security/build.gradle.kts
+++ b/core/security/build.gradle.kts
@@ -1,9 +1,14 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.jetbrains.kotlin.android)
     alias(libs.plugins.hilt.android)
-    alias(libs.plugins.kotlin.kapt)
+    alias(libs.plugins.ksp)
     alias(libs.plugins.kotlinx.kover)
+}
+
+kotlin {
+    compilerOptions {
+        languageVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_0
+    }
 }
 
 android {
@@ -19,10 +24,9 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
-    kotlinOptions { jvmTarget = "1.8" }
 
     externalNativeBuild {
         cmake {
@@ -33,5 +37,5 @@ android {
 
 dependencies {
     implementation(libs.hilt.android)
-    kapt(libs.hilt.compiler)
+    ksp(libs.hilt.compiler)
 }

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -1,8 +1,13 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.jetbrains.kotlin.android)
     alias(libs.plugins.kotlin.compose.compiler)
     alias(libs.plugins.kotlinx.kover)
+}
+
+kotlin {
+    compilerOptions {
+        languageVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_0
+    }
 }
 
 android {
@@ -10,10 +15,9 @@ android {
     compileSdk = libs.versions.compileSdk.get().toInt()
     defaultConfig { minSdk = libs.versions.minSdk.get().toInt() }
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
-    kotlinOptions { jvmTarget = "1.8" }
     buildFeatures { compose = true }
 
     flavorDimensions += "environment"
@@ -29,6 +33,7 @@ dependencies {
     implementation(libs.androidx.ui)
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
+    implementation(libs.compose.material.icons)
     implementation(libs.androidx.material3)
     implementation(libs.androidx.material3.adaptive)
     implementation(libs.androidx.material3.window.size.clazz)

--- a/feature/favorites/api/build.gradle.kts
+++ b/feature/favorites/api/build.gradle.kts
@@ -1,10 +1,15 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.jetbrains.kotlin.android)
     alias(libs.plugins.hilt.android)
-    alias(libs.plugins.kotlin.kapt)
+    alias(libs.plugins.ksp)
     alias(libs.plugins.kotlin.seriazation)
     alias(libs.plugins.kotlinx.kover)
+}
+
+kotlin {
+    compilerOptions {
+        languageVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_0
+    }
 }
 
 android {
@@ -20,10 +25,9 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
-    kotlinOptions { jvmTarget = "1.8" }
 }
 
 dependencies {
@@ -33,7 +37,7 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
 
     implementation(libs.hilt.android)
-    kapt(libs.hilt.compiler)
+    ksp(libs.hilt.compiler)
 
     testImplementation(libs.junit)
     testImplementation(libs.mockk)

--- a/feature/favorites/impl/build.gradle.kts
+++ b/feature/favorites/impl/build.gradle.kts
@@ -1,11 +1,16 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.jetbrains.kotlin.android)
     alias(libs.plugins.hilt.android)
-    alias(libs.plugins.kotlin.kapt)
+    alias(libs.plugins.ksp)
     alias(libs.plugins.kotlin.seriazation)
     alias(libs.plugins.kotlin.compose.compiler)
     alias(libs.plugins.kotlinx.kover)
+}
+
+kotlin {
+    compilerOptions {
+        languageVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_0
+    }
 }
 
 android {
@@ -36,12 +41,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-
-    kotlinOptions {
-        jvmTarget = "1.8"
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
 
     buildFeatures {
@@ -64,6 +65,7 @@ dependencies {
     implementation(libs.androidx.ui)
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
+    implementation(libs.compose.material.icons)
     implementation(libs.androidx.material3)
     implementation(libs.androidx.material3.adaptive)
     implementation(libs.androidx.material3.window.size.clazz)
@@ -72,7 +74,7 @@ dependencies {
     implementation(libs.kotlinx.serialization.json)
 
     implementation(libs.hilt.android)
-    kapt(libs.hilt.compiler)
+    ksp(libs.hilt.compiler)
     implementation(libs.hilt.navigation.compose)
 
     debugImplementation(libs.androidx.ui.tooling)

--- a/feature/users/api/build.gradle.kts
+++ b/feature/users/api/build.gradle.kts
@@ -1,8 +1,13 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.jetbrains.kotlin.android)
     alias(libs.plugins.kotlin.seriazation)
     alias(libs.plugins.kotlinx.kover)
+}
+
+kotlin {
+    compilerOptions {
+        languageVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_0
+    }
 }
 
 android {
@@ -18,10 +23,9 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
-    kotlinOptions { jvmTarget = "1.8" }
 }
 
 dependencies {

--- a/feature/users/impl/build.gradle.kts
+++ b/feature/users/impl/build.gradle.kts
@@ -1,11 +1,16 @@
 plugins {
     alias(libs.plugins.android.library)
-    alias(libs.plugins.jetbrains.kotlin.android)
     alias(libs.plugins.hilt.android)
-    alias(libs.plugins.kotlin.kapt)
+    alias(libs.plugins.ksp)
     alias(libs.plugins.kotlin.seriazation)
     alias(libs.plugins.kotlin.compose.compiler)
     alias(libs.plugins.kotlinx.kover)
+}
+
+kotlin {
+    compilerOptions {
+        languageVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_0
+    }
 }
 
 android {
@@ -36,12 +41,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
-    }
-
-    kotlinOptions {
-        jvmTarget = "1.8"
+        sourceCompatibility = JavaVersion.VERSION_11
+        targetCompatibility = JavaVersion.VERSION_11
     }
 
     buildFeatures {
@@ -65,6 +66,7 @@ dependencies {
     implementation(libs.androidx.ui)
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)
+    implementation(libs.compose.material.icons)
     implementation(libs.androidx.material3)
     implementation(libs.androidx.material3.adaptive)
     implementation(libs.androidx.material3.window.size.clazz)
@@ -74,7 +76,7 @@ dependencies {
     implementation(libs.kotlinx.collections.immutable)
 
     implementation(libs.hilt.android)
-    kapt(libs.hilt.compiler)
+    ksp(libs.hilt.compiler)
     implementation(libs.hilt.navigation.compose)
 
     implementation(libs.androidx.paging.compose)

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,4 +9,3 @@ kotlin.incremental=true
 kotlin.incremental.java=true
 android.nonTransitiveRClass=true
 android.disableMinifyLocalDependenciesForLibraries=false
-android.enableR8.fullMode=false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,49 +1,50 @@
 [versions]
-compileSdk = "35"
+compileSdk = "36"
 minSdk = "28"
-targetSdk = "35"
-agp = "8.6.1"
-kotlin = "2.0.20"
-kover = "0.7.6"
+targetSdk = "36"
+agp = "9.1.0"
+kotlin = "2.2.20"
+ksp = "2.3.4"
+kover = "0.9.8"
 
-kotlinCoroutines = "1.9.0"
-kotlinSerialization = "1.7.2"
-kotlinxCollectionsImmutable = "0.3.8"
+kotlinCoroutines = "1.10.2"
+kotlinSerialization = "1.10.0"
+kotlinxCollectionsImmutable = "0.4.0"
 
-coreKtx = "1.15.0"
-lifecycleRuntimeKtx = "2.8.7"
+coreKtx = "1.18.0"
+lifecycleRuntimeKtx = "2.10.0"
 
-activityCompose = "1.9.3"
-composeBom = "2024.12.01"
-navigationCompose = "2.8.5"
-coreTest = "1.6.1"
+activityCompose = "1.13.0"
+composeBom = "2026.03.01"
+navigationCompose = "2.9.7"
+coreTest = "1.7.0"
 
-hilt = "2.52"
-hiltNavigationCompose = "1.2.0"
+hilt = "2.59.2"
+hiltNavigationCompose = "1.3.0"
 
 room = "2.8.4"
 sqliteKtx = "2.6.2"
-sqlcipherAndroid = "4.14.0"
-paging = "3.3.5"
+sqlcipherAndroid = "4.14.1"
+paging = "3.4.2"
 securityCryptoDatastore = "1.0.0"
 
-retrofit = "2.11.0"
-gson = "2.10.1"
-okhttp3 = "4.12.0"
+retrofit = "3.0.0"
+gson = "2.13.2"
+okhttp3 = "5.3.2"
 
-coil = "3.0.4"
+coil = "3.4.0"
 
 timber = "5.0.1"
 
 leakcanaryAndroid = "2.14"
 
 junit = "4.13.2"
-junitVersion = "1.2.1"
-espressoCore = "3.6.1"
-mockk = "1.12.1"
-kotest = "5.0.0"
-turbine = "1.1.0"
-robolectric = "4.14.1"
+junitVersion = "1.3.0"
+espressoCore = "3.7.0"
+mockk = "1.14.9"
+kotest = "6.1.10"
+turbine = "1.2.1"
+robolectric = "4.16.1"
 mediationTestSuite = "3.0.0"
 
 [libraries]
@@ -59,6 +60,7 @@ androidx-ui-tooling = { group = "androidx.compose.ui", name = "ui-tooling" }
 androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 androidx-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
+compose-material-icons = { group = "androidx.compose.material", name = "material-icons-extended" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3" }
 androidx-material3-adaptive = { group = "androidx.compose.material3.adaptive", name = "adaptive" }
 androidx-material3-window-size-clazz = { group = "androidx.compose.material3", name = "material3-window-size-class" }
@@ -117,7 +119,8 @@ android-application = { id = "com.android.application", version.ref = "agp" }
 jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 android-library = { id = "com.android.library", version.ref = "agp" }
 hilt-android = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
-kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 kotlin-seriazation = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 kotlin-compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlinx-kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }
+androidx-room = { id = "androidx.room", version.ref = "room" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sat Jul 20 11:01:51 ICT 2024
+#Tue Apr 07 18:04:18 ICT 2026
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.3.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
- Upgrade Kotlin to 2.2.20, AGP to 9.1.0, and Gradle to 9.3.1
- Replace Kapt with KSP for Hilt and Room annotation processing across all modules
- Update Java source and target compatibility to Version 11
- Bump compileSdk and targetSdk to 36
- Integrate the AndroidX Room Gradle plugin and update Kover configuration for version 0.9.8
- Update core dependencies including Compose BOM (2026.03.01), Hilt, Retrofit, and OkHttp