### PR TITLE
refactor: migrate hiltViewModel to new package and use explicit types

### DIFF
--- a/feature/favorites/impl/src/main/java/com/tyme/github/users/feature/favorites/presentation/favorites/FavoritesScreen.kt
+++ b/feature/favorites/impl/src/main/java/com/tyme/github/users/feature/favorites/presentation/favorites/FavoritesScreen.kt
@@ -18,7 +18,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.tyme.github.users.core.ui.components.Loading
 import com.tyme.github.users.core.ui.components.RemoveFavoriteDialog
@@ -30,7 +30,7 @@ import com.tyme.github.users.feature.favorites.impl.R
 @Composable
 fun FavoritesScreen(
     onUrlClick: (String) -> Unit,
-    viewModel: FavoritesViewModel = hiltViewModel(),
+    viewModel: FavoritesViewModel = hiltViewModel<FavoritesViewModel>(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     FavoritesContent(

--- a/feature/users/impl/src/main/java/com/tyme/github/users/feature/users/presentation/userdetails/UserDetailsScreen.kt
+++ b/feature/users/impl/src/main/java/com/tyme/github/users/feature/users/presentation/userdetails/UserDetailsScreen.kt
@@ -19,7 +19,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.tyme.github.users.core.ui.components.BackButton
 import com.tyme.github.users.core.ui.components.ErrorDialog
@@ -32,7 +32,7 @@ import com.tyme.github.users.feature.users.presentation.userdetails.components.U
 @Composable
 fun UserDetailsScreen(
     onUrlClick: (String) -> Unit,
-    viewModel: UserDetailsViewModel = hiltViewModel(),
+    viewModel: UserDetailsViewModel = hiltViewModel<UserDetailsViewModel>(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val isFavorite by viewModel.isFavorite.collectAsStateWithLifecycle()

--- a/feature/users/impl/src/main/java/com/tyme/github/users/feature/users/presentation/userlist/UserListScreen.kt
+++ b/feature/users/impl/src/main/java/com/tyme/github/users/feature/users/presentation/userlist/UserListScreen.kt
@@ -17,7 +17,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.material3.Surface
 import androidx.paging.LoadState


### PR DESCRIPTION
Replace deprecated import androidx.hilt.navigation.compose.hiltViewModel
with androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel across all
screens, and add explicit type parameters where missing.
