### PR TITLE
refactor: migrate favorites from Paging 3 to Flow<List> for smooth item removal

### DIFF
--- a/core/ui/src/main/java/com/tyme/github/users/core/ui/components/UserCard.kt
+++ b/core/ui/src/main/java/com/tyme/github/users/core/ui/components/UserCard.kt
@@ -24,10 +24,7 @@ import com.tyme.github.users.core.ui.theme.Theme
 
 @Composable
 fun UserCard(
-    username: String,
-    avatarUrl: String,
-    url: String,
-    isFavorite: Boolean,
+    item: UserListItem,
     modifier: Modifier = Modifier,
     onUserClick: () -> Unit = {},
     onFavoriteClick: () -> Unit = {},
@@ -42,7 +39,7 @@ fun UserCard(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             UserAvatar(
-                avatarUrl = avatarUrl,
+                avatarUrl = item.avatarUrl,
                 modifier = Modifier.size(90.dp),
             )
             Column(
@@ -51,23 +48,23 @@ fun UserCard(
                     .padding(start = 12.dp),
             ) {
                 Text(
-                    text = username,
+                    text = item.username,
                     style = MaterialTheme.typography.titleMedium,
                 )
                 HorizontalDivider(
                     modifier = Modifier.padding(vertical = 4.dp),
                 )
                 LinkText(
-                    url = url,
+                    url = item.url,
                     onClick = onUrlClick,
                     style = MaterialTheme.typography.bodyMedium,
                 )
             }
             IconButton(onClick = onFavoriteClick) {
                 Icon(
-                    imageVector = if (isFavorite) Icons.Filled.Favorite else Icons.Filled.FavoriteBorder,
+                    imageVector = if (item.isFavorite) Icons.Filled.Favorite else Icons.Filled.FavoriteBorder,
                     contentDescription = null,
-                    tint = if (isFavorite) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
+                    tint = if (item.isFavorite) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.onSurfaceVariant,
                 )
             }
         }
@@ -79,10 +76,12 @@ fun UserCard(
 private fun UserCardFavoritePreview() {
     Theme {
         UserCard(
-            username = "JohnDoe",
-            avatarUrl = "",
-            url = "https://github.com/johndoe",
-            isFavorite = true,
+            item = UserListItem(
+                username = "JohnDoe",
+                avatarUrl = "",
+                url = "https://github.com/johndoe",
+                isFavorite = true,
+            ),
         )
     }
 }
@@ -92,10 +91,12 @@ private fun UserCardFavoritePreview() {
 private fun UserCardNotFavoritePreview() {
     Theme {
         UserCard(
-            username = "JohnDoe",
-            avatarUrl = "",
-            url = "https://github.com/johndoe",
-            isFavorite = false,
+            item = UserListItem(
+                username = "JohnDoe",
+                avatarUrl = "",
+                url = "https://github.com/johndoe",
+                isFavorite = false,
+            ),
         )
     }
 }

--- a/core/ui/src/main/java/com/tyme/github/users/core/ui/components/UserList.kt
+++ b/core/ui/src/main/java/com/tyme/github/users/core/ui/components/UserList.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyGridScope
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material3.Button
@@ -34,14 +35,7 @@ fun UserList(
     onFavoriteClick: (UserListItem) -> Unit = {},
     onUrlClick: (String) -> Unit = {},
 ) {
-    val arrangement = Arrangement.spacedBy(12.dp)
-    LazyVerticalGrid(
-        columns = GridCells.Adaptive(256.dp),
-        modifier = modifier,
-        verticalArrangement = arrangement,
-        horizontalArrangement = arrangement,
-        contentPadding = PaddingValues(16.dp),
-    ) {
+    UserListGrid(modifier) {
         items(
             count = pagingItems.itemCount,
             key = pagingItems.itemKey { user -> user.id },
@@ -88,14 +82,7 @@ fun UserList(
     onFavoriteClick: (UserListItem) -> Unit = {},
     onUrlClick: (String) -> Unit = {},
 ) {
-    val arrangement = Arrangement.spacedBy(12.dp)
-    LazyVerticalGrid(
-        columns = GridCells.Adaptive(256.dp),
-        modifier = modifier,
-        verticalArrangement = arrangement,
-        horizontalArrangement = arrangement,
-        contentPadding = PaddingValues(16.dp),
-    ) {
+    UserListGrid(modifier) {
         items(
             items = items,
             key = { it.id },
@@ -108,6 +95,22 @@ fun UserList(
             )
         }
     }
+}
+
+@Composable
+private fun UserListGrid(
+    modifier: Modifier = Modifier,
+    content: LazyGridScope.() -> Unit,
+) {
+    val arrangement = Arrangement.spacedBy(12.dp)
+    LazyVerticalGrid(
+        columns = GridCells.Adaptive(256.dp),
+        modifier = modifier,
+        verticalArrangement = arrangement,
+        horizontalArrangement = arrangement,
+        contentPadding = PaddingValues(16.dp),
+        content = content,
+    )
 }
 
 @Preview
@@ -123,5 +126,20 @@ private fun UserListPagingPreview() {
         }
         val pagingItems = flowOf(PagingData.from(userList)).collectAsLazyPagingItems()
         UserList(pagingItems = pagingItems)
+    }
+}
+
+@Preview
+@Composable
+private fun UserListPreview() {
+    Theme {
+        val userList = List(10) { index ->
+            UserListItem(
+                id = index,
+                username = "user$index",
+                url = "https://www.github.com/user$index",
+            )
+        }
+        UserList(items = userList)
     }
 }

--- a/core/ui/src/main/java/com/tyme/github/users/core/ui/components/UserList.kt
+++ b/core/ui/src/main/java/com/tyme/github/users/core/ui/components/UserList.kt
@@ -47,10 +47,7 @@ fun UserList(
         ) { index ->
             val user = pagingItems[index] ?: return@items
             UserCard(
-                username = user.username,
-                avatarUrl = user.avatarUrl,
-                url = user.url,
-                isFavorite = user.isFavorite,
+                item = user,
                 onUserClick = { onUserClick(user) },
                 onFavoriteClick = { onFavoriteClick(user) },
                 onUrlClick = onUrlClick,

--- a/core/ui/src/main/java/com/tyme/github/users/core/ui/components/UserList.kt
+++ b/core/ui/src/main/java/com/tyme/github/users/core/ui/components/UserList.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Text
@@ -75,6 +76,36 @@ fun UserList(
             }
 
             else -> {}
+        }
+    }
+}
+
+@Composable
+fun UserList(
+    items: List<UserListItem>,
+    modifier: Modifier = Modifier,
+    onUserClick: (UserListItem) -> Unit = {},
+    onFavoriteClick: (UserListItem) -> Unit = {},
+    onUrlClick: (String) -> Unit = {},
+) {
+    val arrangement = Arrangement.spacedBy(12.dp)
+    LazyVerticalGrid(
+        columns = GridCells.Adaptive(256.dp),
+        modifier = modifier,
+        verticalArrangement = arrangement,
+        horizontalArrangement = arrangement,
+        contentPadding = PaddingValues(16.dp),
+    ) {
+        items(
+            items = items,
+            key = { it.id },
+        ) { user ->
+            UserCard(
+                item = user,
+                onUserClick = { onUserClick(user) },
+                onFavoriteClick = { onFavoriteClick(user) },
+                onUrlClick = onUrlClick,
+            )
         }
     }
 }

--- a/feature/favorites/api/build.gradle.kts
+++ b/feature/favorites/api/build.gradle.kts
@@ -34,7 +34,6 @@ dependencies {
     implementation(project(":core:common"))
 
     implementation(libs.kotlinx.coroutines.android)
-    implementation(libs.androidx.paging.runtime.ktx)
     implementation(libs.kotlinx.serialization.json)
 
     implementation(libs.hilt.android)

--- a/feature/favorites/api/src/main/java/com/tyme/github/users/feature/favorites/api/repository/FavoriteRepository.kt
+++ b/feature/favorites/api/src/main/java/com/tyme/github/users/feature/favorites/api/repository/FavoriteRepository.kt
@@ -1,6 +1,5 @@
 package com.tyme.github.users.feature.favorites.api.repository
 
-import androidx.paging.PagingData
 import com.tyme.github.users.core.common.models.UserModel
 import kotlinx.coroutines.flow.Flow
 
@@ -12,5 +11,5 @@ interface FavoriteRepository {
 
     fun isFavorite(username: String): Flow<Boolean>
 
-    fun getFavoritePaging(): Flow<PagingData<UserModel>>
+    fun getFavorites(): Flow<List<UserModel>>
 }

--- a/feature/favorites/api/src/main/java/com/tyme/github/users/feature/favorites/domain/usecase/GetFavoritesUseCase.kt
+++ b/feature/favorites/api/src/main/java/com/tyme/github/users/feature/favorites/domain/usecase/GetFavoritesUseCase.kt
@@ -1,13 +1,12 @@
 package com.tyme.github.users.feature.favorites.domain.usecase
 
-import androidx.paging.PagingData
 import com.tyme.github.users.core.common.models.UserModel
 import com.tyme.github.users.feature.favorites.api.repository.FavoriteRepository
 import kotlinx.coroutines.flow.Flow
 import javax.inject.Inject
 
-class GetFavoritePagingUseCase @Inject constructor(
+class GetFavoritesUseCase @Inject constructor(
     private val repository: FavoriteRepository,
 ) {
-    operator fun invoke(): Flow<PagingData<UserModel>> = repository.getFavoritePaging()
+    operator fun invoke(): Flow<List<UserModel>> = repository.getFavorites()
 }

--- a/feature/favorites/api/src/test/java/com/tyme/github/users/feature/favorites/domain/usecase/GetFavoritesUseCaseTest.kt
+++ b/feature/favorites/api/src/test/java/com/tyme/github/users/feature/favorites/domain/usecase/GetFavoritesUseCaseTest.kt
@@ -1,0 +1,62 @@
+package com.tyme.github.users.feature.favorites.domain.usecase
+
+import app.cash.turbine.test
+import com.tyme.github.users.core.common.models.UserModel
+import com.tyme.github.users.feature.favorites.api.repository.FavoriteRepository
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+
+internal class GetFavoritesUseCaseTest {
+
+    private val favoriteRepository = mockk<FavoriteRepository>()
+
+    private val useCase = GetFavoritesUseCase(favoriteRepository)
+
+    @Test
+    fun `invoke emits list of favorites from repository`() = runTest {
+        // Given
+        val favorites = listOf(
+            UserModel(id = 1, username = "user1", isFavorite = true),
+            UserModel(id = 2, username = "user2", isFavorite = true),
+        )
+        every { favoriteRepository.getFavorites() } returns flowOf(favorites)
+
+        // When / Then
+        useCase().test {
+            expectMostRecentItem() shouldBe favorites
+        }
+    }
+
+    @Test
+    fun `invoke emits empty list when there are no favorites`() = runTest {
+        // Given
+        every { favoriteRepository.getFavorites() } returns flowOf(emptyList())
+
+        // When / Then
+        useCase().test {
+            expectMostRecentItem() shouldBe emptyList()
+        }
+    }
+
+    @Test
+    fun `invoke emits multiple updates as favorites change`() = runTest {
+        // Given
+        val first = listOf(UserModel(id = 1, username = "user1", isFavorite = true))
+        val second = listOf(
+            UserModel(id = 1, username = "user1", isFavorite = true),
+            UserModel(id = 2, username = "user2", isFavorite = true),
+        )
+        every { favoriteRepository.getFavorites() } returns flowOf(first, second)
+
+        // When / Then
+        useCase().test {
+            awaitItem() shouldBe first
+            awaitItem() shouldBe second
+            awaitComplete()
+        }
+    }
+}

--- a/feature/favorites/impl/build.gradle.kts
+++ b/feature/favorites/impl/build.gradle.kts
@@ -71,7 +71,6 @@ dependencies {
     implementation(libs.androidx.material3.adaptive)
     implementation(libs.androidx.material3.window.size.clazz)
     implementation(libs.androidx.navigation.compose)
-    implementation(libs.androidx.paging.compose)
 
     implementation(libs.kotlinx.serialization.json)
 
@@ -81,7 +80,6 @@ dependencies {
 
     debugImplementation(libs.androidx.ui.tooling)
 
-    testImplementation(libs.androidx.paging.testing)
     testImplementation(libs.junit)
     testImplementation(libs.mockk)
     testImplementation(libs.kotest)

--- a/feature/favorites/impl/src/main/java/com/tyme/github/users/feature/favorites/data/repository/FavoriteRepositoryImpl.kt
+++ b/feature/favorites/impl/src/main/java/com/tyme/github/users/feature/favorites/data/repository/FavoriteRepositoryImpl.kt
@@ -1,9 +1,5 @@
 package com.tyme.github.users.feature.favorites.data.repository
 
-import androidx.paging.Pager
-import androidx.paging.PagingConfig
-import androidx.paging.PagingData
-import androidx.paging.map
 import com.tyme.github.users.core.common.models.UserModel
 import com.tyme.github.users.core.database.dao.FavoriteDao
 import com.tyme.github.users.feature.favorites.api.repository.FavoriteRepository
@@ -27,8 +23,6 @@ internal class FavoriteRepositoryImpl @Inject constructor(
     override fun isFavorite(username: String): Flow<Boolean> =
         dao.isFavorite(username)
 
-    override fun getFavoritePaging(): Flow<PagingData<UserModel>> = Pager(
-        config = PagingConfig(pageSize = 20, enablePlaceholders = false),
-        pagingSourceFactory = { dao.getFavoritePagingSource() },
-    ).flow.map { pagingData -> pagingData.map { it.toUserModel() } }
+    override fun getFavorites(): Flow<List<UserModel>> =
+        dao.getFavorites().map { list -> list.map { it.toUserModel() } }
 }

--- a/feature/favorites/impl/src/main/java/com/tyme/github/users/feature/favorites/presentation/favorites/FavoritesScreen.kt
+++ b/feature/favorites/impl/src/main/java/com/tyme/github/users/feature/favorites/presentation/favorites/FavoritesScreen.kt
@@ -1,11 +1,16 @@
 package com.tyme.github.users.feature.favorites.presentation.favorites
 
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.grid.GridCells
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
@@ -20,18 +25,12 @@ import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import androidx.paging.LoadState
-import androidx.paging.PagingData
-import androidx.paging.compose.LazyPagingItems
-import androidx.paging.compose.collectAsLazyPagingItems
 import com.tyme.github.users.core.ui.components.ErrorDialog
-import com.tyme.github.users.core.ui.components.Loading
 import com.tyme.github.users.core.ui.components.RemoveFavoriteDialog
-import com.tyme.github.users.core.ui.components.UserList
+import com.tyme.github.users.core.ui.components.UserCard
 import com.tyme.github.users.core.ui.components.UserListItem
 import com.tyme.github.users.core.ui.theme.Theme
 import com.tyme.github.users.feature.favorites.impl.R
-import kotlinx.coroutines.flow.flowOf
 
 @Composable
 fun FavoritesScreen(
@@ -39,7 +38,7 @@ fun FavoritesScreen(
     viewModel: FavoritesViewModel = hiltViewModel<FavoritesViewModel>(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
-    val favorites = viewModel.favorites.collectAsLazyPagingItems()
+    val favorites by viewModel.favorites.collectAsStateWithLifecycle()
     FavoritesContent(
         favorites = favorites,
         uiState = uiState,
@@ -55,7 +54,7 @@ fun FavoritesScreen(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun FavoritesContent(
-    favorites: LazyPagingItems<UserListItem>,
+    favorites: List<UserListItem>,
     uiState: FavoritesUiState,
     onUserClick: (UserListItem) -> Unit = {},
     onRemoveFavoriteClick: (UserListItem) -> Unit = {},
@@ -70,8 +69,7 @@ private fun FavoritesContent(
             windowInsets = TopAppBarDefaults.windowInsets.only(WindowInsetsSides.Horizontal),
         )
         when {
-            favorites.loadState.refresh is LoadState.Loading -> Loading()
-            favorites.itemCount == 0 -> Box(
+            favorites.isEmpty() -> Box(
                 modifier = Modifier
                     .fillMaxSize()
                     .padding(32.dp),
@@ -83,13 +81,27 @@ private fun FavoritesContent(
                 )
             }
 
-            else -> UserList(
-                pagingItems = favorites,
-                onRetryClick = favorites::retry,
-                onUserClick = onUserClick,
-                onFavoriteClick = onRemoveFavoriteClick,
-                onUrlClick = onUrlClick,
-            )
+            else -> {
+                val arrangement = Arrangement.spacedBy(12.dp)
+                LazyVerticalGrid(
+                    columns = GridCells.Adaptive(256.dp),
+                    verticalArrangement = arrangement,
+                    horizontalArrangement = arrangement,
+                    contentPadding = PaddingValues(16.dp),
+                ) {
+                    items(
+                        items = favorites,
+                        key = { it.id },
+                    ) { user ->
+                        UserCard(
+                            item = user,
+                            onUserClick = { onUserClick(user) },
+                            onFavoriteClick = { onRemoveFavoriteClick(user) },
+                            onUrlClick = onUrlClick,
+                        )
+                    }
+                }
+            }
         }
     }
 
@@ -111,9 +123,8 @@ private fun FavoritesContent(
 @Composable
 private fun FavoritesEmptyPreview() {
     Theme {
-        val emptyPaging = flowOf(PagingData.empty<UserListItem>()).collectAsLazyPagingItems()
         FavoritesContent(
-            favorites = emptyPaging,
+            favorites = emptyList(),
             uiState = FavoritesUiState.Idle,
         )
     }
@@ -127,9 +138,8 @@ private fun FavoritesSuccessPreview() {
             UserListItem(1, "JohnDoe", "", "https://github.com/johndoe"),
             UserListItem(2, "JaneSmith", "", "https://github.com/janesmith"),
         )
-        val pagingItems = flowOf(PagingData.from(items)).collectAsLazyPagingItems()
         FavoritesContent(
-            favorites = pagingItems,
+            favorites = items,
             uiState = FavoritesUiState.Idle,
         )
     }

--- a/feature/favorites/impl/src/main/java/com/tyme/github/users/feature/favorites/presentation/favorites/FavoritesScreen.kt
+++ b/feature/favorites/impl/src/main/java/com/tyme/github/users/feature/favorites/presentation/favorites/FavoritesScreen.kt
@@ -1,16 +1,11 @@
 package com.tyme.github.users.feature.favorites.presentation.favorites
 
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.lazy.grid.GridCells
-import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
-import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
@@ -27,7 +22,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.tyme.github.users.core.ui.components.ErrorDialog
 import com.tyme.github.users.core.ui.components.RemoveFavoriteDialog
-import com.tyme.github.users.core.ui.components.UserCard
+import com.tyme.github.users.core.ui.components.UserList
 import com.tyme.github.users.core.ui.components.UserListItem
 import com.tyme.github.users.core.ui.theme.Theme
 import com.tyme.github.users.feature.favorites.impl.R
@@ -81,27 +76,12 @@ private fun FavoritesContent(
                 )
             }
 
-            else -> {
-                val arrangement = Arrangement.spacedBy(12.dp)
-                LazyVerticalGrid(
-                    columns = GridCells.Adaptive(256.dp),
-                    verticalArrangement = arrangement,
-                    horizontalArrangement = arrangement,
-                    contentPadding = PaddingValues(16.dp),
-                ) {
-                    items(
-                        items = favorites,
-                        key = { it.id },
-                    ) { user ->
-                        UserCard(
-                            item = user,
-                            onUserClick = { onUserClick(user) },
-                            onFavoriteClick = { onRemoveFavoriteClick(user) },
-                            onUrlClick = onUrlClick,
-                        )
-                    }
-                }
-            }
+            else -> UserList(
+                items = favorites,
+                onUserClick = onUserClick,
+                onFavoriteClick = onRemoveFavoriteClick,
+                onUrlClick = onUrlClick,
+            )
         }
     }
 

--- a/feature/favorites/impl/src/main/java/com/tyme/github/users/feature/favorites/presentation/favorites/FavoritesUiState.kt
+++ b/feature/favorites/impl/src/main/java/com/tyme/github/users/feature/favorites/presentation/favorites/FavoritesUiState.kt
@@ -8,6 +8,6 @@ sealed interface FavoritesUiState {
     data class ConfirmRemoval(val item: UserListItem) : FavoritesUiState
     data class RemovalError(
         val message: String = "",
-        @StringRes val messageRes: Int = 0,
+        @param:StringRes val messageRes: Int = 0,
     ) : FavoritesUiState
 }

--- a/feature/favorites/impl/src/main/java/com/tyme/github/users/feature/favorites/presentation/favorites/FavoritesViewModel.kt
+++ b/feature/favorites/impl/src/main/java/com/tyme/github/users/feature/favorites/presentation/favorites/FavoritesViewModel.kt
@@ -2,38 +2,36 @@ package com.tyme.github.users.feature.favorites.presentation.favorites
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
-import androidx.paging.PagingData
-import androidx.paging.cachedIn
-import androidx.paging.map
 import com.tyme.github.users.core.navigation.AppNavigator
 import com.tyme.github.users.core.navigation.NavigationIntent
 import com.tyme.github.users.core.common.providers.DispatchersProvider
 import com.tyme.github.users.core.network.models.errors.toNetworkErrorMessage
 import com.tyme.github.users.core.ui.components.UserListItem
-import com.tyme.github.users.feature.favorites.domain.usecase.GetFavoritePagingUseCase
+import com.tyme.github.users.feature.favorites.domain.usecase.GetFavoritesUseCase
 import com.tyme.github.users.feature.favorites.domain.usecase.RemoveFavoriteUseCase
 import com.tyme.github.users.feature.favorites.presentation.mappers.toUserListItem
 import com.tyme.github.users.feature.users.navigation.UserDetailsDestination
 import dagger.hilt.android.lifecycle.HiltViewModel
-import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 @HiltViewModel
 class FavoritesViewModel @Inject constructor(
-    getFavoritePagingUseCase: GetFavoritePagingUseCase,
+    getFavoritesUseCase: GetFavoritesUseCase,
     private val removeFavoriteUseCase: RemoveFavoriteUseCase,
     private val navigator: AppNavigator,
     private val dispatchers: DispatchersProvider,
 ) : ViewModel() {
 
-    val favorites: Flow<PagingData<UserListItem>> = getFavoritePagingUseCase()
-        .map { pagingData -> pagingData.map { it.toUserListItem() } }
-        .cachedIn(viewModelScope)
+    val favorites: StateFlow<List<UserListItem>> = getFavoritesUseCase()
+        .map { list -> list.map { it.toUserListItem() } }
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
     private val _uiState = MutableStateFlow<FavoritesUiState>(FavoritesUiState.Idle)
     val uiState: StateFlow<FavoritesUiState> = _uiState.asStateFlow()

--- a/feature/favorites/impl/src/main/java/com/tyme/github/users/feature/favorites/presentation/favorites/FavoritesViewModel.kt
+++ b/feature/favorites/impl/src/main/java/com/tyme/github/users/feature/favorites/presentation/favorites/FavoritesViewModel.kt
@@ -2,9 +2,9 @@ package com.tyme.github.users.feature.favorites.presentation.favorites
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.tyme.github.users.core.common.providers.DispatchersProvider
 import com.tyme.github.users.core.navigation.AppNavigator
 import com.tyme.github.users.core.navigation.NavigationIntent
-import com.tyme.github.users.core.common.providers.DispatchersProvider
 import com.tyme.github.users.core.network.models.errors.toNetworkErrorMessage
 import com.tyme.github.users.core.ui.components.UserListItem
 import com.tyme.github.users.feature.favorites.domain.usecase.GetFavoritesUseCase
@@ -16,6 +16,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
@@ -31,6 +32,13 @@ class FavoritesViewModel @Inject constructor(
 
     val favorites: StateFlow<List<UserListItem>> = getFavoritesUseCase()
         .map { list -> list.map { it.toUserListItem() } }
+        .catch { throwable ->
+            val errorMessage = throwable.toNetworkErrorMessage()
+            _uiState.value = FavoritesUiState.RemovalError(
+                message = errorMessage.message,
+                messageRes = errorMessage.messageRes,
+            )
+        }
         .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000), emptyList())
 
     private val _uiState = MutableStateFlow<FavoritesUiState>(FavoritesUiState.Idle)

--- a/feature/favorites/impl/src/test/java/com/tyme/github/users/feature/favorites/data/repository/FavoriteRepositoryImplTest.kt
+++ b/feature/favorites/impl/src/test/java/com/tyme/github/users/feature/favorites/data/repository/FavoriteRepositoryImplTest.kt
@@ -1,8 +1,5 @@
 package com.tyme.github.users.feature.favorites.data.repository
 
-import androidx.paging.PagingSource
-import androidx.paging.PagingState
-import androidx.paging.testing.asSnapshot
 import app.cash.turbine.test
 import com.tyme.github.users.core.common.models.UserModel
 import com.tyme.github.users.core.database.dao.FavoriteDao
@@ -103,28 +100,45 @@ internal class FavoriteRepositoryImplTest {
     }
 
     @Test
-    fun `getFavoritePaging returns mapped paging data from dao`() = runTest {
+    fun `getFavorites emits mapped list of UserModel from dao`() = runTest {
         // Given
         val entities = listOf(
             UserEntity(id = 1, username = "user1", avatarUrl = "avatar1", url = "https://github.com/user1", isFavorite = true),
             UserEntity(id = 2, username = "user2", avatarUrl = "avatar2", url = "https://github.com/user2", isFavorite = true),
         )
-        every { dao.getFavoritePagingSource() } returns FakeUserPagingSource(entities)
+        every { dao.getFavorites() } returns flowOf(entities)
 
-        // When
-        val snapshot = repository.getFavoritePaging().asSnapshot()
-
-        // Then
-        snapshot shouldBe entities.map { it.toUserModel() }
+        // When / Then
+        repository.getFavorites().test {
+            expectMostRecentItem() shouldBe entities.map { it.toUserModel() }
+        }
     }
-}
 
-private class FakeUserPagingSource(
-    private val entities: List<UserEntity>,
-) : PagingSource<Int, UserEntity>() {
+    @Test
+    fun `getFavorites emits empty list when dao returns no favorites`() = runTest {
+        // Given
+        every { dao.getFavorites() } returns flowOf(emptyList())
 
-    override fun getRefreshKey(state: PagingState<Int, UserEntity>): Int? = null
+        // When / Then
+        repository.getFavorites().test {
+            expectMostRecentItem() shouldBe emptyList()
+        }
+    }
 
-    override suspend fun load(params: LoadParams<Int>): LoadResult<Int, UserEntity> =
-        LoadResult.Page(data = entities, prevKey = null, nextKey = null)
+    @Test
+    fun `getFavorites emits updated list when dao emits again`() = runTest {
+        // Given
+        val first = listOf(
+            UserEntity(id = 1, username = "user1", avatarUrl = "avatar1", url = "https://github.com/user1", isFavorite = true),
+        )
+        val second = emptyList<UserEntity>()
+        every { dao.getFavorites() } returns flowOf(first, second)
+
+        // When / Then
+        repository.getFavorites().test {
+            awaitItem() shouldBe first.map { it.toUserModel() }
+            awaitItem() shouldBe emptyList()
+            awaitComplete()
+        }
+    }
 }

--- a/feature/favorites/impl/src/test/java/com/tyme/github/users/feature/favorites/presentation/favorites/FavoritesViewModelTest.kt
+++ b/feature/favorites/impl/src/test/java/com/tyme/github/users/feature/favorites/presentation/favorites/FavoritesViewModelTest.kt
@@ -1,12 +1,11 @@
 package com.tyme.github.users.feature.favorites.presentation.favorites
 
-import androidx.paging.PagingData
 import app.cash.turbine.test
 import com.tyme.github.users.core.navigation.AppNavigator
 import com.tyme.github.users.core.navigation.NavigationIntent
 import com.tyme.github.users.core.common.providers.DispatchersProvider
 import com.tyme.github.users.core.ui.components.UserListItem
-import com.tyme.github.users.feature.favorites.domain.usecase.GetFavoritePagingUseCase
+import com.tyme.github.users.feature.favorites.domain.usecase.GetFavoritesUseCase
 import com.tyme.github.users.feature.favorites.domain.usecase.RemoveFavoriteUseCase
 import com.tyme.github.users.feature.users.navigation.UserDetailsDestination
 import io.kotest.matchers.shouldBe
@@ -32,7 +31,7 @@ import org.junit.Test
 internal class FavoritesViewModelTest {
 
     private val testDispatcher = UnconfinedTestDispatcher()
-    private val getFavoritePagingUseCase: GetFavoritePagingUseCase = mockk()
+    private val getFavoritesUseCase: GetFavoritesUseCase = mockk()
     private val removeFavoriteUseCase: RemoveFavoriteUseCase = mockk()
     private val navigator: AppNavigator = mockk()
     private val dispatchers: DispatchersProvider = mockk()
@@ -44,7 +43,7 @@ internal class FavoritesViewModelTest {
         every { dispatchers.main } returns testDispatcher
         every { dispatchers.default } returns testDispatcher
         every { dispatchers.immediate } returns testDispatcher
-        every { getFavoritePagingUseCase() } returns flowOf(PagingData.empty())
+        every { getFavoritesUseCase() } returns flowOf(emptyList())
     }
 
     @After
@@ -53,7 +52,7 @@ internal class FavoritesViewModelTest {
     }
 
     private fun createViewModel() = FavoritesViewModel(
-        getFavoritePagingUseCase = getFavoritePagingUseCase,
+        getFavoritesUseCase = getFavoritesUseCase,
         removeFavoriteUseCase = removeFavoriteUseCase,
         navigator = navigator,
         dispatchers = dispatchers,
@@ -65,6 +64,30 @@ internal class FavoritesViewModelTest {
 
         viewModel.uiState.test {
             awaitItem() shouldBe FavoritesUiState.Idle
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `favorites emits mapped list from use case`() = runTest {
+        // Given
+        val userListItems = listOf(
+            UserListItem(id = 1, username = "user1", isFavorite = true),
+            UserListItem(id = 2, username = "user2", isFavorite = true),
+        )
+        every { getFavoritesUseCase() } returns flowOf(
+            userListItems.map {
+                com.tyme.github.users.core.common.models.UserModel(
+                    id = it.id,
+                    username = it.username,
+                    isFavorite = it.isFavorite,
+                )
+            }
+        )
+        val viewModel = createViewModel()
+
+        viewModel.favorites.test {
+            awaitItem() shouldBe userListItems
             cancelAndIgnoreRemainingEvents()
         }
     }


### PR DESCRIPTION
Replace Flow<PagingData> with Flow<List<UserModel>> backed by Room's existing
getFavorites() query, so removing a favorite no longer invalidates the paging
source and reloads the whole list. FavoritesScreen now renders an inline
LazyVerticalGrid with stable item keys so Compose animates the removal diff
instead of resetting scroll position.

- Replace getFavoritePaging/GetFavoritePagingUseCase with getFavorites/GetFavoritesUseCase
- FavoritesViewModel: favorites is now StateFlow<List<UserListItem>> via stateIn
- FavoritesScreen: collectAsStateWithLifecycle + LazyVerticalGrid(key = { it.id })
- UserCard: refactor signature to accept UserListItem instead of individual fields
- Remove paging-runtime-ktx, paging-compose, paging-testing dependencies
- Update all affected tests; add GetFavoritesUseCaseTest
