### PR TITLE
refactor: migrate UserDetailsScreen to MVI and centralize URL navigation

### DIFF
--- a/app/src/main/java/com/tyme/github/users/navigation/AppNavHost.kt
+++ b/app/src/main/java/com/tyme/github/users/navigation/AppNavHost.kt
@@ -21,10 +21,12 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.rememberNavController
+import androidx.compose.ui.platform.LocalContext
 import com.tyme.github.users.R
 import com.tyme.github.users.core.navigation.AppNavigator
 import com.tyme.github.users.core.navigation.NavigationEffects
 import com.tyme.github.users.core.navigation.NavigationIntent
+import com.tyme.github.users.core.ui.extensions.openBrowser
 import com.tyme.github.users.feature.favorites.navigation.FavoritesDestination
 import com.tyme.github.users.feature.favorites.navigation.favoritesNavGraph
 import com.tyme.github.users.feature.users.navigation.UserListDestination
@@ -37,6 +39,7 @@ internal fun AppNavHost(
     modifier: Modifier = Modifier,
     navController: NavHostController = rememberNavController(),
 ) {
+    val context = LocalContext.current
     val navBackStackEntry by navController.currentBackStackEntryAsState()
     val currentDestination = navBackStackEntry?.destination
     val scope = rememberCoroutineScope()
@@ -59,7 +62,11 @@ internal fun AppNavHost(
         )
     }
 
-    NavigationEffects(navigator = navigator, navController = navController)
+    NavigationEffects(
+        navigator = navigator,
+        navController = navController,
+        onOpenUrl = { url -> context.openBrowser(url) },
+    )
 
     Scaffold(
         modifier = modifier,

--- a/core/navigation/src/main/java/com/tyme/github/users/core/navigation/NavigationEffects.kt
+++ b/core/navigation/src/main/java/com/tyme/github/users/core/navigation/NavigationEffects.kt
@@ -9,6 +9,7 @@ import androidx.navigation.NavHostController
 fun NavigationEffects(
     navigator: AppNavigator,
     navController: NavHostController,
+    onOpenUrl: (String) -> Unit = {},
 ) {
     LaunchedEffect(navigator, navController) {
         navigator.navigationActions.collect { intent ->
@@ -27,6 +28,7 @@ fun NavigationEffects(
                     restoreState = intent.restoreState
                 }
                 NavigationIntent.NavigateUp -> navController.navigateUp()
+                is NavigationIntent.OpenUrl -> onOpenUrl(intent.url)
             }
         }
     }

--- a/core/navigation/src/main/java/com/tyme/github/users/core/navigation/NavigationIntent.kt
+++ b/core/navigation/src/main/java/com/tyme/github/users/core/navigation/NavigationIntent.kt
@@ -13,4 +13,6 @@ sealed interface NavigationIntent {
     ) : NavigationIntent
 
     data object NavigateUp : NavigationIntent
+
+    data class OpenUrl(val url: String) : NavigationIntent
 }

--- a/core/ui/build.gradle.kts
+++ b/core/ui/build.gradle.kts
@@ -31,6 +31,7 @@ android {
 dependencies {
     implementation(project(":core:common"))
     implementation(platform(libs.androidx.compose.bom))
+    implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.ui)
     implementation(libs.androidx.ui.graphics)
     implementation(libs.androidx.ui.tooling.preview)

--- a/core/ui/src/main/java/com/tyme/github/users/core/ui/extensions/ContextExtensions.kt
+++ b/core/ui/src/main/java/com/tyme/github/users/core/ui/extensions/ContextExtensions.kt
@@ -2,11 +2,11 @@ package com.tyme.github.users.core.ui.extensions
 
 import android.content.Context
 import android.content.Intent
-import android.net.Uri
+import androidx.core.net.toUri
 
 fun Context.openBrowser(url: String) {
     runCatching {
-        val intent = Intent(Intent.ACTION_VIEW, Uri.parse(url))
+        val intent = Intent(Intent.ACTION_VIEW, url.toUri())
         startActivity(intent)
     }
 }

--- a/feature/users/impl/src/main/java/com/tyme/github/users/feature/users/navigation/UsersNavGraph.kt
+++ b/feature/users/impl/src/main/java/com/tyme/github/users/feature/users/navigation/UsersNavGraph.kt
@@ -1,10 +1,8 @@
 package com.tyme.github.users.feature.users.navigation
 
-import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import androidx.navigation.navDeepLink
-import com.tyme.github.users.core.ui.extensions.openBrowser
 import com.tyme.github.users.feature.users.presentation.userdetails.UserDetailsScreen
 import com.tyme.github.users.feature.users.presentation.userlist.UserListScreen
 
@@ -14,10 +12,7 @@ fun NavGraphBuilder.usersNavGraph() {
             navDeepLink<UserListDestination>(UsersDeepLinks.USER_LIST_PATH),
         ),
     ) {
-        val context = LocalContext.current
-        UserListScreen(
-            onUrlClick = { url -> context.openBrowser(url) },
-        )
+        UserListScreen()
     }
 
     composable<UserDetailsDestination>(
@@ -25,9 +20,6 @@ fun NavGraphBuilder.usersNavGraph() {
             navDeepLink<UserDetailsDestination>(UsersDeepLinks.USER_DETAILS_PATH),
         ),
     ) {
-        val context = LocalContext.current
-        UserDetailsScreen(
-            onUrlClick = { url -> context.openBrowser(url) },
-        )
+        UserDetailsScreen()
     }
 }

--- a/feature/users/impl/src/main/java/com/tyme/github/users/feature/users/presentation/userdetails/UserDetailsScreen.kt
+++ b/feature/users/impl/src/main/java/com/tyme/github/users/feature/users/presentation/userdetails/UserDetailsScreen.kt
@@ -40,12 +40,13 @@ fun UserDetailsScreen(
     UserDetailsContent(
         uiState = uiState,
         isFavorite = isFavorite,
-        onBackClick = viewModel::onNavigateBack,
-        onBlogClick = onUrlClick,
-        onFavoriteToggle = viewModel::onFavoriteClick,
-        onConfirmRemoveFavorite = viewModel::onConfirmRemoveFavorite,
-        onDismissRemoveFavorite = viewModel::onDismissRemoveFavorite,
-        onDismissError = viewModel::dismissError,
+        onAction = { action ->
+            if (action is UserDetailsUiAction.BlogClick) {
+                onUrlClick(action.url)
+            } else {
+                viewModel.onAction(action)
+            }
+        },
     )
 }
 
@@ -54,21 +55,16 @@ fun UserDetailsScreen(
 private fun UserDetailsContent(
     uiState: UserDetailUiState,
     isFavorite: Boolean,
-    onBackClick: () -> Unit,
-    onBlogClick: (String) -> Unit,
-    onFavoriteToggle: () -> Unit,
-    onConfirmRemoveFavorite: () -> Unit,
-    onDismissRemoveFavorite: () -> Unit,
-    onDismissError: () -> Unit,
+    onAction: (UserDetailsUiAction) -> Unit,
 ) {
     Column(modifier = Modifier.fillMaxSize()) {
         CenterAlignedTopAppBar(
             title = { Text(text = stringResource(R.string.user_details_title)) },
-            navigationIcon = { BackButton(onClick = onBackClick) },
+            navigationIcon = { BackButton(onClick = { onAction(UserDetailsUiAction.NavigateBack) }) },
             windowInsets = TopAppBarDefaults.windowInsets.only(WindowInsetsSides.Horizontal),
             actions = {
                 if (uiState is UserDetailUiState.Success) {
-                    IconButton(onClick = onFavoriteToggle) {
+                    IconButton(onClick = { onAction(UserDetailsUiAction.FavoriteToggle) }) {
                         Icon(
                             imageVector = if (isFavorite) Icons.Filled.Favorite else Icons.Filled.FavoriteBorder,
                             contentDescription = null,
@@ -83,20 +79,20 @@ private fun UserDetailsContent(
             is UserDetailUiState.Loading -> Loading()
             is UserDetailUiState.Success -> UserDetails(
                 uiState = uiState,
-                onBlogClick = onBlogClick,
+                onBlogClick = { url -> onAction(UserDetailsUiAction.BlogClick(url)) },
                 modifier = Modifier.fillMaxSize(),
             )
             is UserDetailUiState.Error -> ErrorDialog(
                 message = uiState.message.asString(),
-                onDismiss = onDismissError,
+                onDismiss = { onAction(UserDetailsUiAction.DismissError) },
             )
         }
     }
     if (uiState is UserDetailUiState.Success && uiState.showRemoveConfirmDialog) {
         RemoveFavoriteDialog(
             username = uiState.username,
-            onConfirm = onConfirmRemoveFavorite,
-            onDismiss = onDismissRemoveFavorite,
+            onConfirm = { onAction(UserDetailsUiAction.ConfirmRemoveFavorite) },
+            onDismiss = { onAction(UserDetailsUiAction.DismissRemoveFavorite) },
         )
     }
 }
@@ -115,12 +111,7 @@ private fun UserDetailsContentPreview() {
                 url = "https://github.com/mojombo"
             ),
             isFavorite = true,
-            onBackClick = {},
-            onBlogClick = {},
-            onFavoriteToggle = {},
-            onConfirmRemoveFavorite = {},
-            onDismissRemoveFavorite = {},
-            onDismissError = {}
+            onAction = {},
         )
     }
 }

--- a/feature/users/impl/src/main/java/com/tyme/github/users/feature/users/presentation/userdetails/UserDetailsScreen.kt
+++ b/feature/users/impl/src/main/java/com/tyme/github/users/feature/users/presentation/userdetails/UserDetailsScreen.kt
@@ -32,7 +32,6 @@ import com.tyme.github.users.feature.users.presentation.userdetails.components.U
 
 @Composable
 fun UserDetailsScreen(
-    onUrlClick: (String) -> Unit,
     viewModel: UserDetailsViewModel = hiltViewModel<UserDetailsViewModel>(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -40,13 +39,7 @@ fun UserDetailsScreen(
     UserDetailsContent(
         uiState = uiState,
         isFavorite = isFavorite,
-        onAction = { action ->
-            if (action is UserDetailsUiAction.BlogClick) {
-                onUrlClick(action.url)
-            } else {
-                viewModel.onAction(action)
-            }
-        },
+        onAction = viewModel::onAction,
     )
 }
 

--- a/feature/users/impl/src/main/java/com/tyme/github/users/feature/users/presentation/userdetails/UserDetailsUiAction.kt
+++ b/feature/users/impl/src/main/java/com/tyme/github/users/feature/users/presentation/userdetails/UserDetailsUiAction.kt
@@ -1,0 +1,10 @@
+package com.tyme.github.users.feature.users.presentation.userdetails
+
+sealed interface UserDetailsUiAction {
+    data object NavigateBack : UserDetailsUiAction
+    data object FavoriteToggle : UserDetailsUiAction
+    data object ConfirmRemoveFavorite : UserDetailsUiAction
+    data object DismissRemoveFavorite : UserDetailsUiAction
+    data object DismissError : UserDetailsUiAction
+    data class BlogClick(val url: String) : UserDetailsUiAction
+}

--- a/feature/users/impl/src/main/java/com/tyme/github/users/feature/users/presentation/userdetails/UserDetailsViewModel.kt
+++ b/feature/users/impl/src/main/java/com/tyme/github/users/feature/users/presentation/userdetails/UserDetailsViewModel.kt
@@ -63,7 +63,18 @@ class UserDetailsViewModel @Inject constructor(
         }
     }
 
-    fun onFavoriteClick() {
+    fun onAction(action: UserDetailsUiAction) {
+        when (action) {
+            UserDetailsUiAction.NavigateBack -> onNavigateBack()
+            UserDetailsUiAction.FavoriteToggle -> onFavoriteClick()
+            UserDetailsUiAction.ConfirmRemoveFavorite -> onConfirmRemoveFavorite()
+            UserDetailsUiAction.DismissRemoveFavorite -> onDismissRemoveFavorite()
+            UserDetailsUiAction.DismissError -> dismissError()
+            is UserDetailsUiAction.BlogClick -> Unit
+        }
+    }
+
+    private fun onFavoriteClick() {
         if (isFavorite.value) {
             _uiState.update { current ->
                 if (current is UserDetailUiState.Success) current.copy(showRemoveConfirmDialog = true) else current
@@ -81,7 +92,7 @@ class UserDetailsViewModel @Inject constructor(
         }
     }
 
-    fun onConfirmRemoveFavorite() {
+    private fun onConfirmRemoveFavorite() {
         _uiState.update { current ->
             if (current is UserDetailUiState.Success) current.copy(showRemoveConfirmDialog = false) else current
         }
@@ -91,17 +102,17 @@ class UserDetailsViewModel @Inject constructor(
         }
     }
 
-    fun onDismissRemoveFavorite() {
+    private fun onDismissRemoveFavorite() {
         _uiState.update { current ->
             if (current is UserDetailUiState.Success) current.copy(showRemoveConfirmDialog = false) else current
         }
     }
 
-    fun dismissError() {
+    private fun dismissError() {
         _uiState.value = UserDetailUiState.Idle
     }
 
-    fun onNavigateBack() {
+    private fun onNavigateBack() {
         viewModelScope.launch { navigator.navigate(NavigationIntent.NavigateUp) }
     }
 }

--- a/feature/users/impl/src/main/java/com/tyme/github/users/feature/users/presentation/userdetails/UserDetailsViewModel.kt
+++ b/feature/users/impl/src/main/java/com/tyme/github/users/feature/users/presentation/userdetails/UserDetailsViewModel.kt
@@ -70,9 +70,12 @@ class UserDetailsViewModel @Inject constructor(
             UserDetailsUiAction.ConfirmRemoveFavorite -> onConfirmRemoveFavorite()
             UserDetailsUiAction.DismissRemoveFavorite -> onDismissRemoveFavorite()
             UserDetailsUiAction.DismissError -> dismissError()
-            is UserDetailsUiAction.BlogClick ->
-                viewModelScope.launch { navigator.navigate(NavigationIntent.OpenUrl(action.url)) }
+            is UserDetailsUiAction.BlogClick -> onBlogClick(action)
         }
+    }
+
+    private fun onBlogClick(action: UserDetailsUiAction.BlogClick) {
+        viewModelScope.launch { navigator.navigate(NavigationIntent.OpenUrl(action.url)) }
     }
 
     private fun onFavoriteClick() {

--- a/feature/users/impl/src/main/java/com/tyme/github/users/feature/users/presentation/userdetails/UserDetailsViewModel.kt
+++ b/feature/users/impl/src/main/java/com/tyme/github/users/feature/users/presentation/userdetails/UserDetailsViewModel.kt
@@ -70,7 +70,8 @@ class UserDetailsViewModel @Inject constructor(
             UserDetailsUiAction.ConfirmRemoveFavorite -> onConfirmRemoveFavorite()
             UserDetailsUiAction.DismissRemoveFavorite -> onDismissRemoveFavorite()
             UserDetailsUiAction.DismissError -> dismissError()
-            is UserDetailsUiAction.BlogClick -> Unit
+            is UserDetailsUiAction.BlogClick ->
+                viewModelScope.launch { navigator.navigate(NavigationIntent.OpenUrl(action.url)) }
         }
     }
 

--- a/feature/users/impl/src/main/java/com/tyme/github/users/feature/users/presentation/userlist/UserListScreen.kt
+++ b/feature/users/impl/src/main/java/com/tyme/github/users/feature/users/presentation/userlist/UserListScreen.kt
@@ -17,8 +17,10 @@ import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.tyme.github.users.core.ui.extensions.openBrowser
 import androidx.compose.material3.Surface
 import androidx.paging.LoadState
 import androidx.paging.LoadStates
@@ -38,9 +40,9 @@ import kotlinx.coroutines.flow.flowOf
 
 @Composable
 fun UserListScreen(
-    onUrlClick: (String) -> Unit,
     viewModel: UserListViewModel = hiltViewModel<UserListViewModel>(),
 ) {
+    val context = LocalContext.current
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val pagingItems = viewModel.userPaging.collectAsLazyPagingItems()
 
@@ -62,7 +64,7 @@ fun UserListScreen(
         onFavoriteClick = viewModel::onFavoriteClick,
         onConfirmRemoveFavorite = viewModel::onConfirmRemoveFavorite,
         onDismissRemoveFavorite = viewModel::onDismissRemoveFavorite,
-        onUrlClick = onUrlClick,
+        onUrlClick = { url -> context.openBrowser(url) },
         onDismissError = viewModel::dismissError,
     )
 }

--- a/feature/users/impl/src/test/java/com/tyme/github/users/feature/users/presentation/userdetails/UserDetailsViewModelTest.kt
+++ b/feature/users/impl/src/test/java/com/tyme/github/users/feature/users/presentation/userdetails/UserDetailsViewModelTest.kt
@@ -133,7 +133,7 @@ internal class UserDetailsViewModelTest {
         advanceUntilIdle()
 
         // When
-        viewModel.onFavoriteClick()
+        viewModel.onAction(UserDetailsUiAction.FavoriteToggle)
 
         // Then
         (viewModel.uiState.value as UserDetailUiState.Success).showRemoveConfirmDialog shouldBe true
@@ -151,7 +151,7 @@ internal class UserDetailsViewModelTest {
         val viewModel = createViewModel()
 
         // When
-        viewModel.onFavoriteClick()
+        viewModel.onAction(UserDetailsUiAction.FavoriteToggle)
 
         // Then
         coVerify { addFavoriteUseCase(expectedUser) }
@@ -165,10 +165,10 @@ internal class UserDetailsViewModelTest {
         val viewModel = createViewModel()
         backgroundScope.launch { viewModel.isFavorite.collect {} }
         advanceUntilIdle()
-        viewModel.onFavoriteClick()
+        viewModel.onAction(UserDetailsUiAction.FavoriteToggle)
 
         // When
-        viewModel.onConfirmRemoveFavorite()
+        viewModel.onAction(UserDetailsUiAction.ConfirmRemoveFavorite)
 
         // Then
         coVerify { removeFavoriteUseCase(destination.username) }
@@ -182,10 +182,10 @@ internal class UserDetailsViewModelTest {
         val viewModel = createViewModel()
         backgroundScope.launch { viewModel.isFavorite.collect {} }
         advanceUntilIdle()
-        viewModel.onFavoriteClick()
+        viewModel.onAction(UserDetailsUiAction.FavoriteToggle)
 
         // When
-        viewModel.onDismissRemoveFavorite()
+        viewModel.onAction(UserDetailsUiAction.DismissRemoveFavorite)
 
         // Then
         (viewModel.uiState.value as UserDetailUiState.Success).showRemoveConfirmDialog shouldBe false
@@ -198,7 +198,7 @@ internal class UserDetailsViewModelTest {
         val viewModel = createViewModel()
 
         // When
-        viewModel.dismissError()
+        viewModel.onAction(UserDetailsUiAction.DismissError)
 
         // Then
         viewModel.uiState.value shouldBe UserDetailUiState.Idle
@@ -211,7 +211,7 @@ internal class UserDetailsViewModelTest {
         val viewModel = createViewModel()
 
         // When
-        viewModel.onNavigateBack()
+        viewModel.onAction(UserDetailsUiAction.NavigateBack)
 
         // Then
         coVerify { navigator.navigate(NavigationIntent.NavigateUp) }

--- a/feature/users/impl/src/test/java/com/tyme/github/users/feature/users/presentation/userdetails/UserDetailsViewModelTest.kt
+++ b/feature/users/impl/src/test/java/com/tyme/github/users/feature/users/presentation/userdetails/UserDetailsViewModelTest.kt
@@ -218,6 +218,20 @@ internal class UserDetailsViewModelTest {
     }
 
     @Test
+    fun `onAction BlogClick navigates to OpenUrl`() = runTest {
+        // Given
+        coEvery { navigator.navigate(any()) } returns Unit
+        val viewModel = createViewModel()
+
+        // When
+        viewModel.onAction(UserDetailsUiAction.BlogClick("https://example.com"))
+        advanceUntilIdle()
+
+        // Then
+        coVerify { navigator.navigate(NavigationIntent.OpenUrl("https://example.com")) }
+    }
+
+    @Test
     fun `isFavorite emits value from use case`() = runTest {
         // Given
         every { isFavoriteUseCase(destination.username) } returns flowOf(true)


### PR DESCRIPTION
This refactor introduces a Model-View-Intent (MVI) pattern for the `UserDetailsScreen` and centralizes the mechanism for opening external URLs across the application.

**Changes:**
- **`UserDetailsScreen` Refactor**: Converts the `UserDetailsScreen` to adhere to the MVI pattern by consolidating all UI events into a single `onAction` callback, which accepts instances of the new `UserDetailsUiAction` sealed interface.
- **`UserDetailsViewModel` Updates**: The ViewModel now processes `UserDetailsUiAction` events, triggering appropriate business logic or navigation commands. Blog link clicks are specifically handled by dispatching a new `NavigationIntent.OpenUrl`.
- **Centralized URL Navigation**: Introduces `NavigationIntent.OpenUrl` to standardize external URL handling. The `AppNavHost` now provides an `onOpenUrl` callback to `NavigationEffects`, which executes the browser opening when an `OpenUrl` intent is received. This decouples URL opening from individual UI components.
- **Dependency Update**: Adds the `androidx.core.ktx` dependency, required for modern URI extension functions.
- **`ContextExtensions` Enhancement**: Updates the `openBrowser` extension function to utilize the `toUri()` extension from `androidx.core.net`, promoting consistent and modern Android development practices.

**Why this change:**
- Improves the architectural consistency and testability of the `UserDetailsScreen` by implementing the MVI pattern, leading to clearer separation of concerns.
- Standardizes and centralizes how external URLs are opened, reducing boilerplate and potential inconsistencies across different parts of the application.
- Decouples the responsibility of opening external links from the UI layer components, moving it into the core navigation system.