### PR TITLE
refactor: migrate Favorites screen to MVI architecture

### DIFF
--- a/feature/favorites/impl/src/main/java/com/tyme/github/users/feature/favorites/navigation/FavoritesNavGraph.kt
+++ b/feature/favorites/impl/src/main/java/com/tyme/github/users/feature/favorites/navigation/FavoritesNavGraph.kt
@@ -1,17 +1,11 @@
 package com.tyme.github.users.feature.favorites.navigation
 
-import androidx.compose.ui.platform.LocalContext
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
-import com.tyme.github.users.core.ui.extensions.openBrowser
-import com.tyme.github.users.feature.favorites.navigation.FavoritesDestination
 import com.tyme.github.users.feature.favorites.presentation.favorites.FavoritesScreen
 
 fun NavGraphBuilder.favoritesNavGraph() {
     composable<FavoritesDestination> {
-        val context = LocalContext.current
-        FavoritesScreen(
-            onUrlClick = { url -> context.openBrowser(url) },
-        )
+        FavoritesScreen()
     }
 }

--- a/feature/favorites/impl/src/main/java/com/tyme/github/users/feature/favorites/presentation/favorites/FavoritesScreen.kt
+++ b/feature/favorites/impl/src/main/java/com/tyme/github/users/feature/favorites/presentation/favorites/FavoritesScreen.kt
@@ -30,7 +30,6 @@ import com.tyme.github.users.feature.favorites.impl.R
 
 @Composable
 fun FavoritesScreen(
-    onUrlClick: (String) -> Unit,
     viewModel: FavoritesViewModel = hiltViewModel<FavoritesViewModel>(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -38,12 +37,7 @@ fun FavoritesScreen(
     FavoritesContent(
         favorites = favorites,
         uiState = uiState,
-        onUserClick = viewModel::onNavigateToUser,
-        onRemoveFavoriteClick = viewModel::onRemoveFavoriteClick,
-        onConfirmRemoveFavorite = viewModel::onConfirmRemoveFavorite,
-        onDismissRemoveFavorite = viewModel::onDismissRemoveFavorite,
-        onDismissError = viewModel::onDismissError,
-        onUrlClick = onUrlClick,
+        onAction = viewModel::onAction,
     )
 }
 
@@ -52,12 +46,7 @@ fun FavoritesScreen(
 private fun FavoritesContent(
     favorites: List<UserListItem>,
     uiState: FavoritesUiState,
-    onUserClick: (UserListItem) -> Unit = {},
-    onRemoveFavoriteClick: (UserListItem) -> Unit = {},
-    onConfirmRemoveFavorite: () -> Unit = {},
-    onDismissRemoveFavorite: () -> Unit = {},
-    onDismissError: () -> Unit = {},
-    onUrlClick: (String) -> Unit = {},
+    onAction: (FavoritesUiAction) -> Unit = {},
 ) {
     Column(modifier = Modifier.fillMaxSize()) {
         CenterAlignedTopAppBar(
@@ -79,9 +68,9 @@ private fun FavoritesContent(
 
             else -> UserList(
                 items = favorites,
-                onUserClick = onUserClick,
-                onFavoriteClick = onRemoveFavoriteClick,
-                onUrlClick = onUrlClick,
+                onUserClick = { onAction(FavoritesUiAction.UserClick(it)) },
+                onFavoriteClick = { onAction(FavoritesUiAction.RemoveFavoriteClick(it)) },
+                onUrlClick = { onAction(FavoritesUiAction.UrlClick(it)) },
             )
         }
     }
@@ -89,12 +78,12 @@ private fun FavoritesContent(
     when (uiState) {
         is FavoritesUiState.ConfirmRemoval -> RemoveFavoriteDialog(
             username = uiState.item.username,
-            onConfirm = onConfirmRemoveFavorite,
-            onDismiss = onDismissRemoveFavorite,
+            onConfirm = { onAction(FavoritesUiAction.ConfirmRemoveFavorite) },
+            onDismiss = { onAction(FavoritesUiAction.DismissRemoveFavorite) },
         )
         is FavoritesUiState.RemovalError -> ErrorDialog(
             message = uiState.message.asString(),
-            onDismiss = onDismissError,
+            onDismiss = { onAction(FavoritesUiAction.DismissError) },
         )
         FavoritesUiState.Idle -> Unit
     }

--- a/feature/favorites/impl/src/main/java/com/tyme/github/users/feature/favorites/presentation/favorites/FavoritesUiAction.kt
+++ b/feature/favorites/impl/src/main/java/com/tyme/github/users/feature/favorites/presentation/favorites/FavoritesUiAction.kt
@@ -1,0 +1,12 @@
+package com.tyme.github.users.feature.favorites.presentation.favorites
+
+import com.tyme.github.users.core.ui.components.UserListItem
+
+sealed interface FavoritesUiAction {
+    data class UserClick(val user: UserListItem) : FavoritesUiAction
+    data class RemoveFavoriteClick(val user: UserListItem) : FavoritesUiAction
+    data object ConfirmRemoveFavorite : FavoritesUiAction
+    data object DismissRemoveFavorite : FavoritesUiAction
+    data object DismissError : FavoritesUiAction
+    data class UrlClick(val url: String) : FavoritesUiAction
+}

--- a/feature/favorites/impl/src/main/java/com/tyme/github/users/feature/favorites/presentation/favorites/FavoritesViewModel.kt
+++ b/feature/favorites/impl/src/main/java/com/tyme/github/users/feature/favorites/presentation/favorites/FavoritesViewModel.kt
@@ -38,11 +38,22 @@ class FavoritesViewModel @Inject constructor(
     private val _uiState = MutableStateFlow<FavoritesUiState>(FavoritesUiState.Idle)
     val uiState: StateFlow<FavoritesUiState> = _uiState.asStateFlow()
 
-    fun onRemoveFavoriteClick(user: UserListItem) {
+    fun onAction(action: FavoritesUiAction) {
+        when (action) {
+            is FavoritesUiAction.UserClick -> onNavigateToUser(action.user)
+            is FavoritesUiAction.RemoveFavoriteClick -> onRemoveFavoriteClick(action.user)
+            FavoritesUiAction.ConfirmRemoveFavorite -> onConfirmRemoveFavorite()
+            FavoritesUiAction.DismissRemoveFavorite -> onDismissRemoveFavorite()
+            FavoritesUiAction.DismissError -> onDismissError()
+            is FavoritesUiAction.UrlClick -> onUrlClick(action.url)
+        }
+    }
+
+    private fun onRemoveFavoriteClick(user: UserListItem) {
         _uiState.value = FavoritesUiState.ConfirmRemoval(user)
     }
 
-    fun onConfirmRemoveFavorite() {
+    private fun onConfirmRemoveFavorite() {
         val item = (_uiState.value as? FavoritesUiState.ConfirmRemoval)?.item ?: return
         _uiState.value = FavoritesUiState.Idle
         viewModelScope.launch(dispatchers.io) {
@@ -51,15 +62,15 @@ class FavoritesViewModel @Inject constructor(
         }
     }
 
-    fun onDismissRemoveFavorite() {
+    private fun onDismissRemoveFavorite() {
         _uiState.value = FavoritesUiState.Idle
     }
 
-    fun onDismissError() {
+    private fun onDismissError() {
         _uiState.value = FavoritesUiState.Idle
     }
 
-    fun onNavigateToUser(user: UserListItem) {
+    private fun onNavigateToUser(user: UserListItem) {
         viewModelScope.launch {
             navigator.navigate(
                 NavigationIntent.NavigateTo(
@@ -71,5 +82,9 @@ class FavoritesViewModel @Inject constructor(
                 )
             )
         }
+    }
+
+    private fun onUrlClick(url: String) {
+        viewModelScope.launch { navigator.navigate(NavigationIntent.OpenUrl(url)) }
     }
 }

--- a/feature/favorites/impl/src/test/java/com/tyme/github/users/feature/favorites/presentation/favorites/FavoritesViewModelTest.kt
+++ b/feature/favorites/impl/src/test/java/com/tyme/github/users/feature/favorites/presentation/favorites/FavoritesViewModelTest.kt
@@ -93,11 +93,11 @@ internal class FavoritesViewModelTest {
     }
 
     @Test
-    fun `onRemoveFavoriteClick sets ConfirmRemoval state`() = runTest {
+    fun `onAction RemoveFavoriteClick sets ConfirmRemoval state`() = runTest {
         val userListItem = UserListItem(username = "user1")
         val viewModel = createViewModel()
 
-        viewModel.onRemoveFavoriteClick(userListItem)
+        viewModel.onAction(FavoritesUiAction.RemoveFavoriteClick(userListItem))
 
         viewModel.uiState.test {
             awaitItem() shouldBe FavoritesUiState.ConfirmRemoval(userListItem)
@@ -106,13 +106,13 @@ internal class FavoritesViewModelTest {
     }
 
     @Test
-    fun `onConfirmRemoveFavorite calls removeFavoriteUseCase and resets to Idle`() = runTest {
+    fun `onAction ConfirmRemoveFavorite calls removeFavoriteUseCase and resets to Idle`() = runTest {
         val userListItem = UserListItem(username = "user1")
         coEvery { removeFavoriteUseCase(userListItem.username) } returns Result.success(Unit)
         val viewModel = createViewModel()
-        viewModel.onRemoveFavoriteClick(userListItem)
+        viewModel.onAction(FavoritesUiAction.RemoveFavoriteClick(userListItem))
 
-        viewModel.onConfirmRemoveFavorite()
+        viewModel.onAction(FavoritesUiAction.ConfirmRemoveFavorite)
 
         coVerify { removeFavoriteUseCase(userListItem.username) }
         viewModel.uiState.test {
@@ -122,13 +122,13 @@ internal class FavoritesViewModelTest {
     }
 
     @Test
-    fun `onConfirmRemoveFavorite emits RemovalError when removal fails`() = runTest {
+    fun `onAction ConfirmRemoveFavorite emits RemovalError when removal fails`() = runTest {
         val userListItem = UserListItem(username = "user1")
         coEvery { removeFavoriteUseCase(userListItem.username) } returns Result.failure(RuntimeException("db error"))
         val viewModel = createViewModel()
-        viewModel.onRemoveFavoriteClick(userListItem)
+        viewModel.onAction(FavoritesUiAction.RemoveFavoriteClick(userListItem))
 
-        viewModel.onConfirmRemoveFavorite()
+        viewModel.onAction(FavoritesUiAction.ConfirmRemoveFavorite)
 
         viewModel.uiState.test {
             awaitItem().shouldBeInstanceOf<FavoritesUiState.RemovalError>()
@@ -137,21 +137,21 @@ internal class FavoritesViewModelTest {
     }
 
     @Test
-    fun `onConfirmRemoveFavorite does nothing when state is Idle`() = runTest {
+    fun `onAction ConfirmRemoveFavorite does nothing when state is Idle`() = runTest {
         val viewModel = createViewModel()
 
-        viewModel.onConfirmRemoveFavorite()
+        viewModel.onAction(FavoritesUiAction.ConfirmRemoveFavorite)
 
         coVerify(exactly = 0) { removeFavoriteUseCase(any()) }
     }
 
     @Test
-    fun `onDismissRemoveFavorite resets state to Idle`() = runTest {
+    fun `onAction DismissRemoveFavorite resets state to Idle`() = runTest {
         val userListItem = UserListItem(username = "user1")
         val viewModel = createViewModel()
-        viewModel.onRemoveFavoriteClick(userListItem)
+        viewModel.onAction(FavoritesUiAction.RemoveFavoriteClick(userListItem))
 
-        viewModel.onDismissRemoveFavorite()
+        viewModel.onAction(FavoritesUiAction.DismissRemoveFavorite)
 
         viewModel.uiState.test {
             awaitItem() shouldBe FavoritesUiState.Idle
@@ -160,14 +160,14 @@ internal class FavoritesViewModelTest {
     }
 
     @Test
-    fun `onDismissError resets state to Idle`() = runTest {
+    fun `onAction DismissError resets state to Idle`() = runTest {
         val userListItem = UserListItem(username = "user1")
         coEvery { removeFavoriteUseCase(userListItem.username) } returns Result.failure(RuntimeException())
         val viewModel = createViewModel()
-        viewModel.onRemoveFavoriteClick(userListItem)
-        viewModel.onConfirmRemoveFavorite()
+        viewModel.onAction(FavoritesUiAction.RemoveFavoriteClick(userListItem))
+        viewModel.onAction(FavoritesUiAction.ConfirmRemoveFavorite)
 
-        viewModel.onDismissError()
+        viewModel.onAction(FavoritesUiAction.DismissError)
 
         viewModel.uiState.test {
             awaitItem() shouldBe FavoritesUiState.Idle
@@ -176,7 +176,7 @@ internal class FavoritesViewModelTest {
     }
 
     @Test
-    fun `onNavigateToUser navigates to UserDetailsDestination`() = runTest {
+    fun `onAction UserClick navigates to UserDetailsDestination`() = runTest {
         val userListItem = UserListItem(
             username = "user1",
             avatarUrl = "avatar",
@@ -185,7 +185,7 @@ internal class FavoritesViewModelTest {
         coEvery { navigator.navigate(any()) } just runs
         val viewModel = createViewModel()
 
-        viewModel.onNavigateToUser(userListItem)
+        viewModel.onAction(FavoritesUiAction.UserClick(userListItem))
 
         coVerify {
             navigator.navigate(
@@ -198,5 +198,16 @@ internal class FavoritesViewModelTest {
                 )
             )
         }
+    }
+
+    @Test
+    fun `onAction UrlClick navigates to NavigationIntent OpenUrl`() = runTest {
+        val url = "https://example.com"
+        coEvery { navigator.navigate(any()) } just runs
+        val viewModel = createViewModel()
+
+        viewModel.onAction(FavoritesUiAction.UrlClick(url))
+
+        coVerify { navigator.navigate(NavigationIntent.OpenUrl(url)) }
     }
 }


### PR DESCRIPTION
- Introduced FavoritesUiAction to unify all UI interactions
- Updated FavoritesViewModel to handle actions via a single onAction entry point
- Updated FavoritesScreen to dispatch actions to the ViewModel
- Moved URL navigation intent handling from FavoritesNavGraph caller into the ViewModel
- Updated FavoritesViewModelTest to verify the new onAction workflow
